### PR TITLE
Add IsButton to TabViewItem

### DIFF
--- a/src/TabView.Sample/Views/AccentTabGallery.xaml
+++ b/src/TabView.Sample/Views/AccentTabGallery.xaml
@@ -128,6 +128,8 @@
                 <controls:TabViewItem
                     Text="Tab 2"
                     ControlTemplate="{StaticResource FabTabItemTemplate}"
+                    IsButton="True"
+                    x:Name="fabTabButton"
                     Style="{StaticResource TabItemStyle}">
                     <controls:TabViewItem.Icon>
                         <FontImageSource

--- a/src/TabView.Sample/Views/FabTabGallery.xaml.cs
+++ b/src/TabView.Sample/Views/FabTabGallery.xaml.cs
@@ -7,6 +7,9 @@ namespace TabView.Sample.Views
         public FabTabGallery()
         {
             InitializeComponent();
+
+            fabTabButton.TabTapped += (s, e) =>
+                DisplayAlert("FAB Tapped", "You tapped the FAB tab, notice how the content didn't change!", "OK"); ;
         }
     }
 }

--- a/src/Xamarin.Forms.TabView/TabView.cs
+++ b/src/Xamarin.Forms.TabView/TabView.cs
@@ -730,10 +730,6 @@ namespace Xamarin.Forms.TabView
                 return;
 
             SelectedIndex = newPosition;
-            _contentContainer.ScrollTo(SelectedIndex);
-
-            Device.BeginInvokeOnMainThread(
-                async () => await _tabStripContainerScroll.ScrollToAsync(_tabStripContent.Children[position], ScrollToPosition.MakeVisible, false));
 
             if (TabItems.Count > 0)
             {
@@ -746,6 +742,15 @@ namespace Xamarin.Forms.TabView
                 }
 
                 var currentTabItem = TabItems[position];
+
+                if (!currentTabItem.IsButton)
+                {
+                    _contentContainer.ScrollTo(SelectedIndex);
+
+                    Device.BeginInvokeOnMainThread(
+                        async () => await _tabStripContainerScroll.ScrollToAsync(_tabStripContent.Children[position], ScrollToPosition.MakeVisible, false));
+                }
+
                 currentTabItem.SizeChanged += OnCurrentTabItemSizeChanged;
                 UpdateTabIndicatorPosition(currentTabItem);
             }

--- a/src/Xamarin.Forms.TabView/TabViewItem.cs
+++ b/src/Xamarin.Forms.TabView/TabViewItem.cs
@@ -197,6 +197,15 @@ namespace Xamarin.Forms.TabView
             set { SetValue(BadgeBackgroundColorSelectedProperty, value); }
         }
 
+        public static readonly BindableProperty IsButtonProperty =
+            BindableProperty.Create(nameof(IsButton), typeof(bool), typeof(TabViewItem), false);
+
+        public bool IsButton
+        {
+            get => (bool)GetValue(IsButtonProperty);
+            set { SetValue(IsButtonProperty, value); }
+        }
+
         public static readonly BindableProperty TapCommandProperty =
            BindableProperty.Create(nameof(TapCommand), typeof(ICommand), typeof(TabViewItem), null);
 


### PR DESCRIPTION
Tabs which can be buttons do not cause the TabView to scroll to their content, but instead just invoke the tapped event.