### PR TITLE
Workaround to fix a Xamarin.Forms CarouselView issue that create a wrong 1px margin

### DIFF
--- a/src/Xamarin.Forms.TabView/TabView.cs
+++ b/src/Xamarin.Forms.TabView/TabView.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.TabView
         readonly Grid _tabStripContent;
         readonly Grid _tabStripContentContainer;
         readonly CarouselView _contentContainer;
+
         readonly List<double> _contentWidthCollection;
         ObservableCollection<TabViewItem> _contentTabItems;
 
@@ -99,6 +100,10 @@ namespace Xamarin.Forms.TabView
                 HorizontalOptions = LayoutOptions.FillAndExpand,
                 VerticalOptions = LayoutOptions.FillAndExpand
             };
+
+            // Workaround to fix a Xamarin.Forms CarouselView issue that create a wrong 1px margin.
+            if (Device.RuntimePlatform == Device.iOS)
+                _contentContainer.Margin = new Thickness(-1, -1, 0, 0);
 
             _mainContainer = new Grid
             {


### PR DESCRIPTION
The issue will be fixed in Xamarin.Forms 5.0 but, for now, apply a workaround.